### PR TITLE
Kafka source fixes

### DIFF
--- a/hydra-kafka8/src/main/java/com/addthis/hydra/kafka/consumer/FetchTask.java
+++ b/hydra-kafka8/src/main/java/com/addthis/hydra/kafka/consumer/FetchTask.java
@@ -106,7 +106,7 @@ class FetchTask implements Runnable {
                 // here. The sourceOffsets map probably *should not* be modified anywhere else outside of next().
                 sourceOffsets.put(sourceIdentifier, startOffset);
             }
-            log.info("starting to consume topic: {}, partition: {} from broker: {}:{} at offset: {}, until offset: {}",
+            log.info("started consuming topic: {}, partition: {}, from broker: {}:{}, at offset: {}, until offset: {}",
                     topic, partitionId, consumer.host(), consumer.port(), startOffset, endOffset);
             // fetch from broker, add to queue (decoder threads will process queue in parallel)
             long offset = startOffset;
@@ -161,7 +161,7 @@ class FetchTask implements Runnable {
                     }
                 }
             }
-            log.info("finished consuming from broker: {}:{}, topic: {}, partition: {}, offset: {}", consumer.host(),
+            log.info("finished consuming topic: {}, partition: {}, from broker: {}:{}, at offset: {}", consumer.host(),
                      consumer.port(), topic, partitionId, offset);
         } catch (BenignKafkaException ignored) {
         } catch (Exception e) {

--- a/hydra-kafka8/src/main/java/com/addthis/hydra/kafka/consumer/FetchTask.java
+++ b/hydra-kafka8/src/main/java/com/addthis/hydra/kafka/consumer/FetchTask.java
@@ -160,8 +160,8 @@ class FetchTask implements Runnable {
                     }
                 }
             }
-            log.info("finished consuming topic: {}, partition: {}, from broker: {}:{}, at offset: {}", consumer.host(),
-                     consumer.port(), topic, partitionId, offset);
+            log.info("finished consuming topic: {}, partition: {}, from broker: {}:{}, at offset: {}",
+                    topic, partitionId, consumer.host(), consumer.port(), offset);
         } catch (BenignKafkaException ignored) {
         } catch (Exception e) {
             log.error("kafka consume thread failed: ", e);


### PR DESCRIPTION
Several fixes to the kafka source, for the most part preventing small amounts of duplicate bundles.
1. When resuming a kafka source, the first fetch requests will return MessageSets that include messages before the requested offset.  Since the offset to continue from occurred in between batch boundaries, the fetch loop will now drop (duplicate) messages until reaching the desired starting offset.
2. When using multiple decode threads, these decoders could potentially shuffle messages causing a partition to be consumed out of order, and earlier marks could overwrite later marks causing duplicate processing on rekick.  This was fixed by using a separate intermediate queue per partition to guarantee ordering in the final shared bundle queue.
3.  Although it was very unlikely to happen (since I think we typically use one task feeder thread?), the second issue pointed out a possible race condition in the source next method.  The fix was to make sure earlier offsets do not overwrite later offsets in the map that is written to marks db on close.
